### PR TITLE
chore: enhance package.json and README for local-stash packages

### DIFF
--- a/.changeset/large-guests-itch.md
+++ b/.changeset/large-guests-itch.md
@@ -1,0 +1,7 @@
+---
+"@wildneo/emitter": patch
+---
+
+chore:enhance package.json for @wildneo/emitter
+
+- Updated package.json with a detailed description, keywords, repository info, homepage, and bugs URL.

--- a/.changeset/tiny-baths-yell.md
+++ b/.changeset/tiny-baths-yell.md
@@ -1,0 +1,10 @@
+---
+"@wildneo/local-stash": patch
+"@wildneo/react-local-stash": patch
+"@wildneo/svelte-local-stash": patch
+---
+
+chore: enhance package.json and README
+
+- Updated package.json with a detailed description, keywords, repository info, homepage, and bugs URL.
+- Added runtime validation example using Zod in README to improve type safety and data integrity.

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wildneo/emitter",
   "version": "1.0.0",
-  "description": "Simple event emitter",
+  "description": "Minimal typed event emitter for TypeScript - zero dependencies",
   "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,9 +11,30 @@
     "prepare": "pnpm build",
     "prepack": "publint"
   },
-  "keywords": [],
+  "keywords": [
+    "emitter",
+    "event-emitter",
+    "events",
+    "eventemitter",
+    "pubsub",
+    "typescript",
+    "typed",
+    "minimal"
+  ],
   "author": "Roman Oskolkov <wild_neo@mail.ru>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wildneo/local-stash.git",
+    "directory": "packages/emitter"
+  },
+  "homepage": "https://github.com/wildneo/local-stash/tree/main/packages/emitter#readme",
+  "bugs": {
+    "url": "https://github.com/wildneo/local-stash/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/local-stash/README.md
+++ b/packages/local-stash/README.md
@@ -204,6 +204,47 @@ const settingsItem = createItem<UserSettingsV2>({
 });
 ```
 
+## Runtime Validation with Zod
+
+Since TypeScript types are erased at runtime, data from localStorage may not match your expected types. Use the `select` option with a validation library like [zod](https://github.com/colinhacks/zod) for runtime type safety:
+
+```typescript
+import { z } from 'zod';
+import { createStash, createItem } from '@wildneo/local-stash';
+
+// Define a schema
+const UserSettingsSchema = z.object({
+  theme: z.enum(['light', 'dark']),
+  fontSize: z.number().min(10).max(24),
+});
+
+type UserSettings = z.infer<typeof UserSettingsSchema>;
+
+const stash = createStash({ storage: localStorage });
+
+const settingsItem = createItem<UserSettings>({
+  stash,
+  key: 'user-settings',
+  select: (data) => {
+    const result = UserSettingsSchema.safeParse(data);
+    if (result.success) {
+      return result.data;
+    }
+    // Return default value if validation fails
+    return { theme: 'light', fontSize: 14 };
+  },
+});
+
+// Now getItem() always returns valid UserSettings or default
+const settings = settingsItem.getItem();
+```
+
+This approach protects against:
+- Corrupted data in storage
+- Data modified via browser DevTools
+- Schema changes between app versions
+- Data from other applications (key collisions)
+
 ## Fake Storage
 
 The `createFakeStorage()` utility creates an in-memory Storage implementation.

--- a/packages/local-stash/package.json
+++ b/packages/local-stash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wildneo/local-stash",
   "version": "1.0.0",
-  "description": "",
+  "description": "Type-safe localStorage wrapper for TypeScript with versioning, data migration, and change subscriptions",
   "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,9 +11,31 @@
     "prepare": "pnpm build",
     "prepack": "publint"
   },
-  "keywords": [],
+  "keywords": [
+    "localstorage",
+    "sessionstorage",
+    "storage",
+    "typescript",
+    "type-safe",
+    "typed-storage",
+    "persist",
+    "versioning",
+    "migration"
+  ],
   "author": "Roman Oskolkov <wild_neo@mail.ru>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wildneo/local-stash.git",
+    "directory": "packages/local-stash"
+  },
+  "homepage": "https://github.com/wildneo/local-stash/tree/main/packages/local-stash#readme",
+  "bugs": {
+    "url": "https://github.com/wildneo/local-stash/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-local-stash/README.md
+++ b/packages/react-local-stash/README.md
@@ -1,6 +1,6 @@
 # @wildneo/react-local-stash
 
-React hook adapter for [@wildneo/local-stash](../local-stash).
+React hook adapter for [@wildneo/local-stash](../@wildneo/local-stash).
 
 ## Installation
 
@@ -125,6 +125,38 @@ Creates a React hook for the given StashItem.
 A hook function that returns `[value, setValue]` tuple:
 - `value: TData | null` - Current stored value or null
 - `setValue: Dispatch<SetStateAction<TData | null>>` - Setter function
+
+## Runtime Validation with Zod
+
+Use the `select` option with [zod](https://github.com/colinhacks/zod) for runtime type safety:
+
+```typescript
+import { z } from 'zod';
+import { createStash, createItem } from '@wildneo/local-stash';
+import { createHook } from '@wildneo/react-local-stash';
+
+const UserSettingsSchema = z.object({
+  theme: z.enum(['light', 'dark']),
+  fontSize: z.number().min(10).max(24),
+});
+
+type UserSettings = z.infer<typeof UserSettingsSchema>;
+
+const stash = createStash({ storage: localStorage });
+
+const settingsItem = createItem<UserSettings>({
+  stash,
+  key: 'user-settings',
+  select: (data) => {
+    const result = UserSettingsSchema.safeParse(data);
+    return result.success ? result.data : { theme: 'light', fontSize: 14 };
+  },
+});
+
+export const useSettings = createHook(settingsItem);
+```
+
+Now the hook always returns validated data or a safe default value.
 
 ## Automatic Sync
 

--- a/packages/react-local-stash/package.json
+++ b/packages/react-local-stash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wildneo/react-local-stash",
   "version": "1.0.1",
-  "description": "",
+  "description": "React hooks for type-safe storage sync",
   "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,9 +11,33 @@
     "prepare": "pnpm build",
     "prepack": "publint"
   },
-  "keywords": [],
+  "keywords": [
+    "react",
+    "hooks",
+    "localstorage",
+    "use-localstorage",
+    "uselocalstorage",
+    "react-hooks",
+    "state",
+    "persist",
+    "storage",
+    "typescript",
+    "type-safe"
+  ],
   "author": "Roman Oskolkov <wild_neo@mail.ru>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wildneo/local-stash.git",
+    "directory": "packages/react-local-stash"
+  },
+  "homepage": "https://github.com/wildneo/local-stash/tree/main/packages/react-local-stash#readme",
+  "bugs": {
+    "url": "https://github.com/wildneo/local-stash/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/svelte-local-stash/README.md
+++ b/packages/svelte-local-stash/README.md
@@ -1,6 +1,6 @@
 # @wildneo/svelte-local-stash
 
-Svelte store adapter for [@wildneo/local-stash](../local-stash).
+Svelte store adapter for [@wildneo/local-stash](../@wildneo/local-stash).
 
 ## Installation
 
@@ -102,6 +102,39 @@ Set value to `null` to remove the item from storage:
   Clear Settings
 </button>
 ```
+
+## Runtime Validation with Zod
+
+Use the `select` option with [zod](https://github.com/colinhacks/zod) for runtime type safety:
+
+```typescript
+// stores.ts
+import { z } from 'zod';
+import { createStash, createItem } from '@wildneo/local-stash';
+import { createStore } from '@wildneo/svelte-local-stash';
+
+const UserSettingsSchema = z.object({
+  theme: z.enum(['light', 'dark']),
+  fontSize: z.number().min(10).max(24),
+});
+
+type UserSettings = z.infer<typeof UserSettingsSchema>;
+
+const stash = createStash({ storage: localStorage });
+
+const settingsItem = createItem<UserSettings>({
+  stash,
+  key: 'user-settings',
+  select: (data) => {
+    const result = UserSettingsSchema.safeParse(data);
+    return result.success ? result.data : { theme: 'light', fontSize: 14 };
+  },
+});
+
+export const settings = createStore(settingsItem);
+```
+
+Now the store always contains validated data or a safe default value.
 
 ## API
 

--- a/packages/svelte-local-stash/package.json
+++ b/packages/svelte-local-stash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wildneo/svelte-local-stash",
   "version": "1.0.0",
-  "description": "",
+  "description": "Svelte writable store for type-safe storage sync",
   "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,9 +11,32 @@
     "prepare": "pnpm build",
     "prepack": "publint"
   },
-  "keywords": [],
+  "keywords": [
+    "svelte",
+    "store",
+    "writable",
+    "localstorage",
+    "svelte-store",
+    "persist",
+    "storage",
+    "typescript",
+    "type-safe",
+    "reactive"
+  ],
   "author": "Roman Oskolkov <wild_neo@mail.ru>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wildneo/local-stash.git",
+    "directory": "packages/svelte-local-stash"
+  },
+  "homepage": "https://github.com/wildneo/local-stash/tree/main/packages/svelte-local-stash#readme",
+  "bugs": {
+    "url": "https://github.com/wildneo/local-stash/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {
@@ -22,9 +45,6 @@
       }
     },
     "./package.json": "./package.json"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
- Updated package.json files for @wildneo/emitter, @wildneo/local-stash, @wildneo/react-local-stash, and @wildneo/svelte-local-stash with detailed descriptions, keywords, repository info, homepage, and bugs URL.
- Added runtime validation examples using Zod in the README files for @wildneo/local-stash, @wildneo/react-local-stash, and @wildneo/svelte-local-stash to improve type safety and data integrity.